### PR TITLE
Bugfix, that allows setting max to 0

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -126,11 +126,11 @@
 
     // min : int
     // min value
-    min : (config.min) ? parseFloat(config.min) : 0,
+    min : (config.min !== undefined) ? parseFloat(config.min) : 0,
 
     // max : int
     // max value
-    max : (config.max) ? parseFloat(config.max) : 100,
+    max : (config.max !== undefined) ? parseFloat(config.max) : 100,
 
     // humanFriendlyDecimal : int
     // number of decimal places for our human friendly number to contain


### PR DESCRIPTION
I spotted a bug, when setting the max to 0.
Since 0 is a falsy value, the maximum was represented as 100.
