### PR TITLE
Allow config.donutStartAngle to be set to 0 degrees

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -194,7 +194,7 @@
 
     // donutStartAngle : int
     // angle to start from when in donut mode
-    donutStartAngle : (config.donutStartAngle) ? config.donutStartAngle : 90,
+    donutStartAngle : (config.donutStartAngle !== undefined) ? config.donutStartAngle : 90,
 
     // valueMinFontSize : int
     // absolute minimum font size for the value


### PR DESCRIPTION
First off, thanks for JustGage, it works great.

`donutStartAngle` uses the default value of `90` whenever the value passed to the constructor is falsey, which includes `0`, meaning we can't use it as an initial value.  Just checking for `undefined` here.
