### PR TITLE
fix #96

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -954,7 +954,7 @@ function getColor(val, pct, col, noGradient, custSec) {
 
 /** Fix Raphael display:none tspan dy attribute bug */
 function setDy(elem, fontSize, txtYpos) {
-  if (!ie || ie > 9) {
+  if ((!ie || ie > 9) && elem.node.firstChild.attributes.dy) {
     elem.node.firstChild.attributes.dy.value = 0;
   }
 }


### PR DESCRIPTION
Browser compatibiliy problem with attributes.dy (Firefox 25.0 among others)

Check if attribute exists before setting it.
