### PR TITLE
Update justgage.js

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -316,7 +316,7 @@
   // overflow values
   if (obj.config.value > obj.config.max) obj.config.value = obj.config.max;
   if (obj.config.value < obj.config.min) obj.config.value = obj.config.min;
-  obj.originalValue = obj.kvLookup('value', config, dataset, -1, 'int');
+  obj.originalValue = obj.kvLookup('value', config, dataset, -1, 'float');
 
   // create canvas
   if (obj.config.id !== null && (document.getElementById(obj.config.id)) !== null) {


### PR DESCRIPTION
-- Fixed an issue with decimals: creating a chart from scratch with a non-integral value was impossible, since the value would have been always parsed as int, and not as float, as it should be (then eventually, settings about decimals to display will take effect).
