### PR TITLE
Add target pointer

### DIFF
--- a/examples/target.html
+++ b/examples/target.html
@@ -1,0 +1,62 @@
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <title>Counter</title>
+    <meta name="viewport" content="width=device-width">
+    <style>
+        .container {
+            width: 450px;
+            margin: 0 auto;
+            text-align: center;
+        }
+        
+        .gauge {
+            width: 450px;
+            height: 450px;
+        }
+        
+        a:link.button,
+        a:active.button,
+        a:visited.button,
+        a:hover.button {
+            margin: 30px 5px 0 2px;
+            padding: 7px 13px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div id="g1" class="gauge"></div>
+        <a href="#" id="g1_refresh">Random Refresh</a>
+    </div>
+    <script src="../raphael-2.1.4.min.js"></script>
+    <script src="../justgage.js"></script>
+    <script>
+        var g1;
+        document.addEventListener("DOMContentLoaded", function (event) {
+            g1 = new JustGage({
+                id: "g1",
+                value: 72,
+                min: 0,
+                max: 100,
+                target: 90,
+                targetPointer: true,
+                targetPointerOptions: {
+                    toplength: 0,
+                    bottomlength: -90,
+                    bottomwidth: 12,
+                    color: '#8e8e93'
+                },
+                hideInnerShadow: true
+            });
+
+            document.getElementById('g1_refresh').addEventListener('click', function () {
+                g1.refresh(getRandomInt(0, 100));
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/examples/target.html
+++ b/examples/target.html
@@ -27,6 +27,14 @@
 </head>
 
 <body>
+    <form>
+        toplength: <br>
+        <input type="range" id="toplength" min=-100 max=100 value=0><input type="text" id="toplengthn" value="0" size=5><br>
+        bottomlength: <br>
+        <input type="range" id="bottomlength" min=-100 max=100 value=-90><input type="text" id="bottomlengthn" value="-90" size=5><br>
+        bottomwidth: <br>
+        <input type="range" id="bottomwidth" min=0 max=100 value=12><input type="text" id="bottomwidthn" value="12" size=5>
+    </form>
     <div class="container">
         <div id="g1" class="gauge"></div>
         <a href="#" id="g1_refresh">Random Refresh</a>
@@ -51,7 +59,27 @@
                 },
                 hideInnerShadow: true
             });
+            
+            changePointer = function () {
+                var tl = document.getElementById('toplength').value;
+                var bl = document.getElementById('bottomlength').value;
+                var bw = document.getElementById('bottomwidth').value;
+                g1.refresh(72, 100, {
+                    targetPointerOptions: { 
+                        toplength: tl,
+                        bottomlength: bl,
+                        bottomwidth: bw
+                     }
+                });
+                document.getElementById('toplengthn').value = tl;
+                document.getElementById('bottomlengthn').value = bl;
+                document.getElementById('bottomwidthn').value = bw;
+            }
 
+            document.getElementById('toplength').addEventListener('input', changePointer);
+            document.getElementById('bottomlength').addEventListener('input', changePointer);
+            document.getElementById('bottomwidth').addEventListener('input', changePointer);
+            
             document.getElementById('g1_refresh').addEventListener('click', function () {
                 g1.refresh(getRandomInt(0, 100));
             });

--- a/justgage.js
+++ b/justgage.js
@@ -248,7 +248,19 @@ JustGage = function(config) {
 
     // pointerOptions : object
     // define pointer look
-    pointerOptions: kvLookup('pointerOptions', config, dataset, [])
+    pointerOptions: kvLookup('pointerOptions', config, dataset, []),
+    
+    // target : float
+    // location for target pointer
+    target: kvLookup('target', config, dataset, 0, 'float'),   
+    
+    // targetPointer : bool
+    // show target pointer
+    targetPointer: kvLookup('targetPointer', config, dataset, false),
+    
+    // targetPointerOptions : object
+    // define target pointer look
+    targetPointerOptions: kvLookup('targetPointerOptions', config, dataset, [])
   };
 
   // variables
@@ -522,16 +534,22 @@ JustGage = function(config) {
   };
 
   // ndl - custom attribute for generating needle path
-  obj.canvas.customAttributes.ndl = function(value, min, max, w, h, dx, dy, gws, donut) {
+  obj.canvas.customAttributes.ndl = function(value, min, max, w, h, dx, dy, gws, donut, needle) {
 
     var dlt = w * 3.5 / 100;
     var dlb = w / 15;
     var dw = w / 100;
 
-    if (obj.config.pointerOptions.toplength != null && obj.config.pointerOptions.toplength != undefined) dlt = obj.config.pointerOptions.toplength;
-    if (obj.config.pointerOptions.bottomlength != null && obj.config.pointerOptions.bottomlength != undefined) dlb = obj.config.pointerOptions.bottomlength;
-    if (obj.config.pointerOptions.bottomwidth != null && obj.config.pointerOptions.bottomwidth != undefined) dw = obj.config.pointerOptions.bottomwidth;
-
+    if (needle) {
+      if (obj.config.obj.config.pointerOptionsinterOptions.toplength != null && obj.config.pointerOptions.toplength != undefined) dlt = obj.config.pointerOptions.toplength;
+      if (obj.config.pointerOptions.bottomlength != null && obj.config.pointerOptions.bottomlength != undefined) dlb = obj.config.pointerOptions.bottomlength;
+      if (obj.config.pointerOptions.bottomwidth != null && obj.config.pointerOptions.bottomwidth != undefined) dw = obj.config.pointerOptions.bottomwidth;
+    } else {
+      if (obj.config.targetPointerOptions.toplength != null && obj.config.targetPointerOptions.toplength != undefined) dlt = obj.config.targetPointerOptions.toplength;
+      if (obj.config.targetPointerOptions.bottomlength != null && obj.config.targetPointerOptions.bottomlength != undefined) dlb = obj.config.targetPointerOptions.bottomlength;
+      if (obj.config.targetPointerOptions.bottomwidth != null && obj.config.targetPointerOptions.bottomwidth != undefined) dw = obj.config.targetPointerOptions.bottomwidth;
+    }
+    
     var alpha, Ro, Ri, Cx, Cy, Xo, Yo, Xi, Yi, Xc, Yc, Xz, Yz, Xa, Ya, Xb, Yb, path;
 
     if (donut) {
@@ -659,7 +677,8 @@ JustGage = function(config) {
         obj.params.dx,
         obj.params.dy,
         obj.config.gaugeWidthScale,
-        obj.config.donut
+        obj.config.donut,
+        true
       ]
     });
 
@@ -667,6 +686,32 @@ JustGage = function(config) {
       obj.needle.transform("r" + obj.config.donutStartAngle + ", " + (obj.params.widgetW / 2 + obj.params.dx) + ", " + (obj.params.widgetH / 1.95 + obj.params.dy));
     }
 
+  }
+  
+  if (obj.config.targetPointer) {
+    // target pointer
+    obj.targetneedle = obj.canvas.path().attr({
+      "stroke": (obj.config.targetPointerOptions.stroke !== null && obj.config.targetPointerOptions.stroke !== undefined) ? obj.config.targetPointerOptions.stroke : "none",
+      "stroke-width": (obj.config.targetPointerOptions.stroke_width !== null && obj.config.targetPointerOptions.stroke_width !== undefined) ? obj.config.targetPointerOptions.stroke_width : 0,
+      "stroke-linecap": (obj.config.targetPointerOptions.stroke_linecap !== null && obj.config.targetPointerOptions.stroke_linecap !== undefined) ? obj.config.targetPointerOptions.stroke_linecap : "square",
+      "fill": (obj.config.targetPointerOptions.color !== null && obj.config.targetPointerOptions.color !== undefined) ? obj.config.targetPointerOptions.color : "#000000",
+      ndl: [
+        obj.config.max,
+        obj.config.min,
+        obj.config.max,
+        obj.params.widgetW,
+        obj.params.widgetH,
+        obj.params.dx,
+        obj.params.dy,
+        obj.config.gaugeWidthScale,
+        obj.config.donut,
+        false
+      ]
+    });
+
+    if (obj.config.donut) {
+      obj.targetneedle.transform("r" + obj.config.donutStartAngle + ", " + (obj.params.widgetW / 2 + obj.params.dx) + ", " + (obj.params.widgetH / 1.95 + obj.params.dy));
+    }
   }
 
   // title
@@ -843,7 +888,25 @@ JustGage = function(config) {
         obj.params.dx,
         obj.params.dy,
         obj.config.gaugeWidthScale,
-        obj.config.donut
+        obj.config.donut,
+        true
+      ]
+    }, obj.config.startAnimationTime, obj.config.startAnimationType);
+  }
+  
+  if (obj.config.targetPointer) {
+    obj.targetneedle.animate({
+      ndl: [
+        obj.config.target,
+        obj.config.min,
+        obj.config.max,
+        obj.params.widgetW,
+        obj.params.widgetH,
+        obj.params.dx,
+        obj.params.dy,
+        obj.config.gaugeWidthScale,
+        obj.config.donut,
+        false
       ]
     }, obj.config.startAnimationTime, obj.config.startAnimationType);
   }
@@ -962,7 +1025,25 @@ JustGage.prototype.refresh = function(val, max, config) {
         obj.params.dx,
         obj.params.dy,
         obj.config.gaugeWidthScale,
-        obj.config.donut
+        obj.config.donut,
+        true
+      ]
+    }, obj.config.refreshAnimationTime, obj.config.refreshAnimationType);
+  }
+     
+  if (obj.config.targetPointer) {
+    obj.targetneedle.animate({
+      ndl: [
+        obj.config.target,
+        obj.config.min,
+        obj.config.max,
+        obj.params.widgetW,
+        obj.params.widgetH,
+        obj.params.dx,
+        obj.params.dy,
+        obj.config.gaugeWidthScale,
+        obj.config.donut,
+        false
       ]
     }, obj.config.refreshAnimationTime, obj.config.refreshAnimationType);
   }


### PR DESCRIPTION

![capture](https://cloud.githubusercontent.com/assets/4541024/15804580/efad454e-2b61-11e6-817a-f0d9fd7042ee.JPG)
Options to add a pointer to indicate a target value. Uses the same options as value pointer eg bottomwidth, toplength etc to display a triangle inside or outside the gauge. See target.html in examples.