### PR TITLE
Fixing filter paths trying to fetch invalid URLs

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -1027,8 +1027,8 @@ JustGage.prototype.generateShadow = function(svg, defs) {
 
   // set shadow
   if (!obj.config.hideInnerShadow) {
-    obj.canvas.canvas.childNodes[2].setAttribute("filter", "url(#" + sid + ")");
-    obj.canvas.canvas.childNodes[3].setAttribute("filter", "url(#" + sid + ")");
+    obj.canvas.canvas.childNodes[2].setAttribute("filter", "url(" + window.location.pathname + "#" + sid + ")");
+    obj.canvas.canvas.childNodes[3].setAttribute("filter", "url(" + window.location.pathname + "#" + sid + ")");
   }
 
   // var clear


### PR DESCRIPTION
This should fix #244, seems to be happening because the "filter: url()" on the SVG path now started to respect the `<base href="/foo">` tag unlike earlier, which results in the browser trying to load the filter from a wrong location.