### PR TITLE
Fix custom section colors (broken in e161c41)

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -1009,9 +1009,9 @@ function kvLookup(key, tablea, tableb, defval, datatype, delimiter) {
 function getColor(val, pct, col, noGradient, custSec) {
 
   var no, inc, colors, percentage, rval, gval, bval, lower, upper, range, rangePct, pctLower, pctUpper, color;
-  var noGradient = noGradient || custSec.length > 0;
+  var noGradient = noGradient || (custSec.ranges != null && custSec.ranges.length > 0);
 
-  if (custSec.length > 0) {
+  if (custSec.ranges != null && custSec.ranges.length > 0) {
     if (custSec.percents === true) val = pct * 100;
     for (var i = 0; i < custSec.ranges.length; i++) {
       if (val >= custSec.ranges[i].lo && val <= custSec.ranges[i].hi) {


### PR DESCRIPTION
The commit e161c41 breaks custom section color functionality.  This fixes that while maintaining null / undefined checks.

Possibly fixes issue 251 as well
