### PR TITLE
Made library commonJs friendly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+//this file is to export the module
+
+  module.exports = require("justgage.js");

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 //this file is to export the module
 
-  module.exports = require("justgage.js");
+  module.exports = require("./justgage.js");

--- a/justgage.js
+++ b/justgage.js
@@ -5,12 +5,6 @@
  * @author Bojan Djuricic (@Toorshia)
  **/
 
-  // am I in a commonJS environment?
-  if(typeof exports === "object" && exports) {
-    // yep, i will import raphael then
-    var Raphael = require('raphael');
-  }
-
 
 JustGage = function(config) {
 
@@ -1186,4 +1180,11 @@ function extend(out) {
   return out;
 };
 
+-// am I in a commonJS environment?		 +
+ -if(typeof exports === "object" && exports) {	
+    // let's import raphael then
+    var Raphael = require('raphael');
+ -  // and i will export myself as a module.		
+ -   module.exports = JustGage;		
+ -}
 

--- a/justgage.js
+++ b/justgage.js
@@ -1180,11 +1180,11 @@ function extend(out) {
   return out;
 };
 
--// am I in a commonJS environment?		 +
- -if(typeof exports === "object" && exports) {	
-    // let's import raphael then
-    var Raphael = require('raphael');
- -  // and i will export myself as a module.		
- -   module.exports = JustGage;		
- -}
+// am I in a commonJS environment?		 +
+if(typeof exports === "object" && exports) {	
+   // let's import raphael then
+   var Raphael = require('raphael');
+   // and i will export myself as a module.		
+   module.exports = JustGage;		
+ }
 

--- a/justgage.js
+++ b/justgage.js
@@ -1186,8 +1186,4 @@ function extend(out) {
   return out;
 };
 
-// am I in a commonJS environment?
-if(typeof exports === "object" && exports) {
-  // yep, i will export myself as a module.
-   module.exports = JustGage;
-}
+

--- a/justgage.js
+++ b/justgage.js
@@ -5,6 +5,13 @@
  * @author Bojan Djuricic (@Toorshia)
  **/
 
+  // am I in a commonJS environment?
+  if(typeof exports === "object" && exports) {
+    // yep, i will import raphael then
+    var Raphael = require('raphael');
+  }
+
+
 JustGage = function(config) {
 
   var obj = this;
@@ -1178,3 +1185,9 @@ function extend(out) {
 
   return out;
 };
+
+// am I in a commonJS environment?
+if(typeof exports === "object" && exports) {
+  // yep, i will export myself as a module.
+   module.exports = JustGage;
+}

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "bugs": {
     "url": "https://github.com/toorshia/justgage/issues"
   },
+  "dependencies": {
+    "raphael":""
+  },
   "homepage": "https://github.com/toorshia/justgage"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "justgage",
   "version": "1.2.2",
   "description": "JustGage is a handy JavaScript plugin for generating and animating nice & clean gauges. It is based on Raphaël library for vector drawing, so it’s completely resolution independent and self-adjusting.",
-  "main": "justgage.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
I love your library, I used it for a project 2 years ago and it served me well, now i need it again but it does not play well with npm, angular 2, webpack, etc so i did a few changes.

My objective was to be able to require it from my angular 2 project that uses webpack at least in this way.

`var JustGage = require('justgage');`

I tested this changes and now everything works right out of the box after doing an npm install.
