### PR TITLE
Prevent example throwing uncaught error

### DIFF
--- a/examples/reverse.html
+++ b/examples/reverse.html
@@ -78,7 +78,7 @@
         max: 100,
         reverse: true,
         gaugeWidthScale: 0.6,
-        customSectors: [{
+        ranges: [{
           color: '#ff0000',
           lo: 50,
           hi: 100
@@ -108,7 +108,7 @@
         humanFriendly : true,
         reverse: true,
         gaugeWidthScale: 1.3,
-        customSectors: [{
+        ranges: [{
           color: "#ff0000",
           lo: 50000,
           hi: 100000


### PR DESCRIPTION
Quick change to reverse.html example so it works. Fixes issue #258. Although there's obviously another deeper issue of checking the parameters inside getColor (probably covered by #251).