### PR TITLE
Update .refresh() to support min value

### DIFF
--- a/examples/refresh-minimum-maximum.html
+++ b/examples/refresh-minimum-maximum.html
@@ -7,14 +7,14 @@
     <meta name="viewport" content="width=device-width">
     <style>
     .container {
-        width: 450px;
+        width: 500px;
         margin: 50px auto 0 auto;
         text-align: center;
     }
 
     .gauge {
-        width: 450px;
-        height: 450px;
+        width: 500px;
+        height: 500px;
     }
 
     a:link.button,
@@ -30,11 +30,11 @@
 <body>
     <div class="container">
         <div id="g1" class="gauge"></div>
-        <a href="#" id="g1_refresh" class="button grey">Random Refresh</a>
+        <a href="#" id="g1_refresh" class="button grey">Random refresh</a>
         <br />
-        <a href="#" id="g1_setmax100" class="button grey">Set Max 100</a>
-        <a href="#" id="g1_setmax200" class="button grey">Set Max 200</a>
-        <a href="#" id="g1_setmax400" class="button grey">Set Max 400</a>
+        <a href="#" id="g1_setmax100" class="button grey">Set min 20, max 100</a>
+        <a href="#" id="g1_setmax200" class="button grey">Set min 30, max 200</a>
+        <a href="#" id="g1_setmax400" class="button grey">Set min 5, max 400</a>
     </div>
     <script src="../raphael-2.1.4.min.js"></script>
     <script src="../justgage.js"></script>
@@ -52,29 +52,22 @@
         });
 
         document.getElementById('g1_refresh').addEventListener('click', function() {
-            g1.refresh(getRandomInt(0, 100));
+            g1.refresh(getRandomInt(5, 400));
+            return false;
         });
 
         document.getElementById('g1_setmax100').addEventListener('click', function() {
-            g1.refresh(g1.originalValue, 100);
-            g1.txtTitle.attr({
-                "text": "Max is 100."
-            });
+            g1.refresh(g1.originalValue, 20, 100);
+            return false;
         });
 
         document.getElementById('g1_setmax200').addEventListener('click', function() {
-            g1.refresh(g1.originalValue, 200);
-            g1.txtTitle.attr({
-                "text": "Whoops, max jumped to 200."
-            });
+            g1.refresh(g1.originalValue, 30, 200);
             return false;
         });
 
         document.getElementById('g1_setmax400').addEventListener('click', function() {
-            g1.refresh(g1.originalValue, 400);
-            g1.txtTitle.attr({
-                "text": "Blimey, max blasted to 400!"
-            });
+            g1.refresh(g1.originalValue, 5, 400);
             return false;
         });
 

--- a/justgage.js
+++ b/justgage.js
@@ -788,15 +788,40 @@ JustGage = function(config) {
 };
 
 /** Refresh gauge level */
-JustGage.prototype.refresh = function(val, max) {
+JustGage.prototype.refresh = function(val, min, max) {
 
   var obj = this;
-  var displayVal, color, max = max || null;
+  var displayVal, color, max = max || null, min = min || null;
+
+  // set new min
+  if (min !== null) {
+    obj.config.min = min;
+    // TODO: update customSectors
+
+    obj.txtMinimum = obj.config.min;
+    if (obj.config.minTxt) {
+      obj.txtMinimum = obj.config.minTxt;
+    } else if (obj.config.humanFriendly) {
+      obj.txtMinimum = humanFriendlyNumber(obj.config.min, obj.config.humanFriendlyDecimal);
+    } else if (obj.config.formatNumber) {
+      obj.txtMinimum = formatNumber(obj.config.min);
+    }
+    if (!obj.config.reverse) {
+      obj.txtMin.attr({
+        "text": obj.txtMinimum
+      });
+      setDy(obj.txtMin, obj.params.minFontSize, obj.params.minY);
+    } else {
+      obj.txtMax.attr({
+        "text": obj.txtMinimum
+      });
+      setDy(obj.txtMax, obj.params.minFontSize, obj.params.minY);
+    }
+  }
 
   // set new max
   if (max !== null) {
     obj.config.max = max;
-    // TODO: update customSectors
 
     obj.txtMaximum = obj.config.max;
     if (obj.config.maxTxt) {
@@ -815,11 +840,7 @@ JustGage.prototype.refresh = function(val, max) {
       obj.txtMin.attr({
         "text": obj.txtMaximum
       });
-      obj.txtMax.attr({
-        "text": obj.txtMinimum
-      });
-      setDy(obj.txtMin, obj.params.minFontSize, obj.params.minY);
-      setDy(obj.txtMax, obj.params.minFontSize, obj.params.minY);
+      setDy(obj.txtMin, obj.params.maxFontSize, obj.params.maxY);
     }
   }
 
@@ -891,7 +912,7 @@ JustGage.prototype.refresh = function(val, max) {
   }
 
   // var clear
-  obj, displayVal, color, max = null;
+  obj, displayVal, color, max, min = null;
 };
 
 /** Destroy gauge object */


### PR DESCRIPTION
If it's already supporting max **why not add min**? To me it seemed very natural to be able, at least, to dynamically change the current value and min/max limits. As bonus, this properly addresses #204 and updates the test/example page.