### PR TITLE
fixed issue in getColor using custSec

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -1005,13 +1005,30 @@ function kvLookup(key, tablea, tableb, defval, datatype, delimiter) {
   return val;
 };
 
+/** Get length (number of elements/keys) of some object */
+function getLen(someObj) {
+  if(someObj.length) return someObj.length
+  
+  if(Object.keys) {
+    return Object.keys(someObj).length
+  }
+  
+  var len = 0;
+  
+  for(var i in someObj) {
+    len++
+  }
+  
+  return len
+}
+
 /** Get color for value */
 function getColor(val, pct, col, noGradient, custSec) {
 
   var no, inc, colors, percentage, rval, gval, bval, lower, upper, range, rangePct, pctLower, pctUpper, color;
   var noGradient = noGradient || custSec.length > 0;
 
-  if (custSec.length > 0) {
+  if (getLen(custSec) > 0) {
     if (custSec.percents === true) val = pct * 100;
     for (var i = 0; i < custSec.ranges.length; i++) {
       if (val >= custSec.ranges[i].lo && val <= custSec.ranges[i].hi) {


### PR DESCRIPTION
custSec is an object, but getColor used custSec.length - this caused problems when using custSec.
simply implemented a method to get an actual length of the object, and replaced custSec.length with getLen(custSec).