### PR TITLE
Added a displayRemaining property 

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -228,7 +228,11 @@ JustGage = function(config) {
 
     // pointerOptions : object
     // define pointer look
-    pointerOptions: kvLookup('pointerOptions', config, dataset, [])
+    pointerOptions: kvLookup('pointerOptions', config, dataset, []),
+
+    // displayRemaining: boolean
+    // replace display number with the number remaining to reach max
+    displayRemaining: kvLookup('displayRemaining', config, dataset, false)
   };
 
   // variables
@@ -703,7 +707,9 @@ JustGage = function(config) {
     obj.originalValue = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
   } else if (obj.config.formatNumber) {
     obj.originalValue = formatNumber(obj.originalValue) + obj.config.symbol;
-  } else {
+  } else if(obj.config.displayRemaining) {
+    obj.originalValue = ((obj.config.max - obj.originalValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+  }  else {
     obj.originalValue = (obj.originalValue * 1).toFixed(obj.config.decimals) + obj.config.symbol;
   }
 


### PR DESCRIPTION
displayRemaining = true will display the difference between the value and max.  Useful if you're interested in seeing how much is left, rather than how much has been used.  (we're using this for parking spots, and it's more useful to show how many are left, rather than how many have been taken)

I was debating submitting this by passing obj into textRenderer, thus giving the renderer the ability to have access to min, max, etc.  If you'd like, let me know and I can resubmit that way instead.