### PR TITLE
Update UMD Template

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -16,7 +16,7 @@
   else {   // browser
     root.JustGage = factory(Raphael);
   }
-}(this, function (Raphael) {
+}(typeof window !== 'undefined' ? window : this, function (Raphael) {
 
   var JustGage = function (config) {
 


### PR DESCRIPTION
Within an ES module, `this` is `undefined`, rather than `window`. This causes `import JustGage from 'justgage'` to fail on line 19: https://github.com/toorshia/justgage/blob/d6308e32a1ad48938c60dbc5b731a97d48e4f32f/justgage.js#L19

My fix is taken from the UMD templates project: https://github.com/umdjs/umd/blob/47e725735b854dfd93c1ca6fcebf1e018bd52606/templates/returnExportsGlobal.js#L32