### PR TITLE
feat: use custom formats when `textRenderer` returns `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,56 +93,56 @@ setInterval(() => {
 
 ## Options
 
-| Name                 | Default                             | Description                                                                         |
-| -------------------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
-| id                   | (required)                          | The HTML container element `id`                                                     |
-| value                | `0`                                 | Value Gauge is showing                                                              |
-| parentNode           | `null`                              | The HTML container element object. Used if `id` is not present                      |
-| defaults             | `false`                             | Defaults parameters to use globally for gauge objects                               |
-| width                | `null`                              | The Gauge width in pixels (Integer)                                                 |
-| height               | `null`                              | The Gauge height in pixels                                                          |
-| valueFontColor       | `#010101`                           | Color of label showing current value                                                |
-| valueFontFamily      | `Arial`                             | Font of label showing current value                                                 |
-| symbol               | `''`                                | Special symbol to show next to value                                                |
-| min                  | `0`                                 | Min value                                                                           |
-| minTxt               | `false`                             | Min value text, overrides `min` if specified                                        |
-| max                  | `100`                               | Max value                                                                           |
-| maxTxt               | `false`                             | Max value text, overrides `max` if specified                                        |
-| reverse              | `false`                             | Reverse min and max                                                                 |
-| humanFriendlyDecimal | `0`                                 | Number of decimal places for our human friendly number to contain                   |
-| textRenderer         | `null`                              | Function applied before redering text `(value) => value`                            |
-| onAnimationEnd       | `null`                              | Function applied after animation is done                                            |
-| gaugeWidthScale      | `1.0`                               | Width of the gauge element                                                          |
-| gaugeColor           | `#edebeb`                           | Background color of gauge element                                                   |
-| label                | `''`                                | Text to show below value                                                            |
-| labelFontColor       | `#b3b3b3`                           | Color of label showing label under value                                            |
-| shadowOpacity        | `0.2`                               | Shadow opacity 0 ~ 1                                                                |
-| shadowSize           | `5`                                 | Inner shadow size                                                                   |
-| shadowVerticalOffset | `3`                                 | How much shadow is offset from top                                                  |
-| levelColors          | `["#a9d70b", "#f9c802", "#ff0000"]` | Colors of indicator, from lower to upper, in RGB format                             |
-| startAnimationTime   | `700`                               | Length of initial animation in milliseconds                                         |
-| startAnimationType   | `>`                                 | Type of initial animation (linear, >, <,  <>, bounce)                               |
-| refreshAnimationTime | `700`                               | Length of refresh animation in milliseconds                                         |
-| refreshAnimationType | `>`                                 | Type of refresh animation (linear, >, <,  <>, bounce)                               |
-| donutStartAngle      | `90`                                | Angle to start from when in donut mode                                              |
-| valueMinFontSize     | `16`                                | Absolute minimum font size for the value label                                      |
-| labelMinFontSize     | `10`                                | Absolute minimum font size for the label                                            |
-| minLabelMinFontSize  | `10`                                | Absolute minimum font size for the min label                                        |
-| maxLabelMinFontSize  | `10`                                | Absolute minimum font size for the man label                                        |
-| hideValue            | `false`                             | Hide value text                                                                     |
-| hideMinMax           | `false`                             | Hide min/max text                                                                   |
-| showInnerShadow      | `false`                             | Show inner shadow                                                                   |
-| humanFriendly        | `false`                             | convert large numbers for min, max, value to human friendly (e.g. 1234567 -> 1.23M) |
-| noGradient           | `false`                             | Whether to use gradual color change for value, or sector-based                      |
-| donut                | `false`                             | Show donut gauge                                                                    |
-| relativeGaugeSize    | `false`                             | Whether gauge size should follow changes in container element size                  |
-| counter              | `false`                             | Animate text value number change                                                    |
-| decimals             | `0`                                 | Number of digits after floating point                                               |
-| customSectors        | `{}`                                | Custom sectors colors. Expects an [object](#Custom-Sectors)                         |
-| formatNumber         | `false`                             | Formats numbers with commas where appropriate                                       |
-| pointer              | `false`                             | Show value pointer                                                                  |
-| pointerOptions       | `{}`                                | Pointer options. Expects an [object](#Pointer-options)                              |
-| displayRemaining     | `false`                             | Replace display number with the value remaining to reach max value                  |
+| Name                 | Default                             | Description                                                                                |
+| -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------ |
+| id                   | (required)                          | The HTML container element `id`                                                            |
+| value                | `0`                                 | Value Gauge is showing                                                                     |
+| parentNode           | `null`                              | The HTML container element object. Used if `id` is not present                             |
+| defaults             | `false`                             | Defaults parameters to use globally for gauge objects                                      |
+| width                | `null`                              | The Gauge width in pixels (Integer)                                                        |
+| height               | `null`                              | The Gauge height in pixels                                                                 |
+| valueFontColor       | `#010101`                           | Color of label showing current value                                                       |
+| valueFontFamily      | `Arial`                             | Font of label showing current value                                                        |
+| symbol               | `''`                                | Special symbol to show next to value                                                       |
+| min                  | `0`                                 | Min value                                                                                  |
+| minTxt               | `false`                             | Min value text, overrides `min` if specified                                               |
+| max                  | `100`                               | Max value                                                                                  |
+| maxTxt               | `false`                             | Max value text, overrides `max` if specified                                               |
+| reverse              | `false`                             | Reverse min and max                                                                        |
+| humanFriendlyDecimal | `0`                                 | Number of decimal places for our human friendly number to contain                          |
+| textRenderer         | `null`                              | Function applied before redering text `(value) => value` return false for common behaviour |
+| onAnimationEnd       | `null`                              | Function applied after animation is done                                                   |
+| gaugeWidthScale      | `1.0`                               | Width of the gauge element                                                                 |
+| gaugeColor           | `#edebeb`                           | Background color of gauge element                                                          |
+| label                | `''`                                | Text to show below value                                                                   |
+| labelFontColor       | `#b3b3b3`                           | Color of label showing label under value                                                   |
+| shadowOpacity        | `0.2`                               | Shadow opacity 0 ~ 1                                                                       |
+| shadowSize           | `5`                                 | Inner shadow size                                                                          |
+| shadowVerticalOffset | `3`                                 | How much shadow is offset from top                                                         |
+| levelColors          | `["#a9d70b", "#f9c802", "#ff0000"]` | Colors of indicator, from lower to upper, in RGB format                                    |
+| startAnimationTime   | `700`                               | Length of initial animation in milliseconds                                                |
+| startAnimationType   | `>`                                 | Type of initial animation (linear, >, <,  <>, bounce)                                      |
+| refreshAnimationTime | `700`                               | Length of refresh animation in milliseconds                                                |
+| refreshAnimationType | `>`                                 | Type of refresh animation (linear, >, <,  <>, bounce)                                      |
+| donutStartAngle      | `90`                                | Angle to start from when in donut mode                                                     |
+| valueMinFontSize     | `16`                                | Absolute minimum font size for the value label                                             |
+| labelMinFontSize     | `10`                                | Absolute minimum font size for the label                                                   |
+| minLabelMinFontSize  | `10`                                | Absolute minimum font size for the min label                                               |
+| maxLabelMinFontSize  | `10`                                | Absolute minimum font size for the man label                                               |
+| hideValue            | `false`                             | Hide value text                                                                            |
+| hideMinMax           | `false`                             | Hide min/max text                                                                          |
+| showInnerShadow      | `false`                             | Show inner shadow                                                                          |
+| humanFriendly        | `false`                             | convert large numbers for min, max, value to human friendly (e.g. 1234567 -> 1.23M)        |
+| noGradient           | `false`                             | Whether to use gradual color change for value, or sector-based                             |
+| donut                | `false`                             | Show donut gauge                                                                           |
+| relativeGaugeSize    | `false`                             | Whether gauge size should follow changes in container element size                         |
+| counter              | `false`                             | Animate text value number change                                                           |
+| decimals             | `0`                                 | Number of digits after floating point                                                      |
+| customSectors        | `{}`                                | Custom sectors colors. Expects an [object](#Custom-Sectors)                                |
+| formatNumber         | `false`                             | Formats numbers with commas where appropriate                                              |
+| pointer              | `false`                             | Show value pointer                                                                         |
+| pointerOptions       | `{}`                                | Pointer options. Expects an [object](#Pointer-options)                                     |
+| displayRemaining     | `false`                             | Replace display number with the value remaining to reach max value                         |
 
 ### Custom Sectors
 

--- a/README.md
+++ b/README.md
@@ -93,56 +93,56 @@ setInterval(() => {
 
 ## Options
 
-| Name                 | Default                             | Description                                                                                |
-| -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------ |
-| id                   | (required)                          | The HTML container element `id`                                                            |
-| value                | `0`                                 | Value Gauge is showing                                                                     |
-| parentNode           | `null`                              | The HTML container element object. Used if `id` is not present                             |
-| defaults             | `false`                             | Defaults parameters to use globally for gauge objects                                      |
-| width                | `null`                              | The Gauge width in pixels (Integer)                                                        |
-| height               | `null`                              | The Gauge height in pixels                                                                 |
-| valueFontColor       | `#010101`                           | Color of label showing current value                                                       |
-| valueFontFamily      | `Arial`                             | Font of label showing current value                                                        |
-| symbol               | `''`                                | Special symbol to show next to value                                                       |
-| min                  | `0`                                 | Min value                                                                                  |
-| minTxt               | `false`                             | Min value text, overrides `min` if specified                                               |
-| max                  | `100`                               | Max value                                                                                  |
-| maxTxt               | `false`                             | Max value text, overrides `max` if specified                                               |
-| reverse              | `false`                             | Reverse min and max                                                                        |
-| humanFriendlyDecimal | `0`                                 | Number of decimal places for our human friendly number to contain                          |
-| textRenderer         | `null`                              | Function applied before redering text `(value) => value` return false for common behaviour |
-| onAnimationEnd       | `null`                              | Function applied after animation is done                                                   |
-| gaugeWidthScale      | `1.0`                               | Width of the gauge element                                                                 |
-| gaugeColor           | `#edebeb`                           | Background color of gauge element                                                          |
-| label                | `''`                                | Text to show below value                                                                   |
-| labelFontColor       | `#b3b3b3`                           | Color of label showing label under value                                                   |
-| shadowOpacity        | `0.2`                               | Shadow opacity 0 ~ 1                                                                       |
-| shadowSize           | `5`                                 | Inner shadow size                                                                          |
-| shadowVerticalOffset | `3`                                 | How much shadow is offset from top                                                         |
-| levelColors          | `["#a9d70b", "#f9c802", "#ff0000"]` | Colors of indicator, from lower to upper, in RGB format                                    |
-| startAnimationTime   | `700`                               | Length of initial animation in milliseconds                                                |
-| startAnimationType   | `>`                                 | Type of initial animation (linear, >, <,  <>, bounce)                                      |
-| refreshAnimationTime | `700`                               | Length of refresh animation in milliseconds                                                |
-| refreshAnimationType | `>`                                 | Type of refresh animation (linear, >, <,  <>, bounce)                                      |
-| donutStartAngle      | `90`                                | Angle to start from when in donut mode                                                     |
-| valueMinFontSize     | `16`                                | Absolute minimum font size for the value label                                             |
-| labelMinFontSize     | `10`                                | Absolute minimum font size for the label                                                   |
-| minLabelMinFontSize  | `10`                                | Absolute minimum font size for the min label                                               |
-| maxLabelMinFontSize  | `10`                                | Absolute minimum font size for the man label                                               |
-| hideValue            | `false`                             | Hide value text                                                                            |
-| hideMinMax           | `false`                             | Hide min/max text                                                                          |
-| showInnerShadow      | `false`                             | Show inner shadow                                                                          |
-| humanFriendly        | `false`                             | convert large numbers for min, max, value to human friendly (e.g. 1234567 -> 1.23M)        |
-| noGradient           | `false`                             | Whether to use gradual color change for value, or sector-based                             |
-| donut                | `false`                             | Show donut gauge                                                                           |
-| relativeGaugeSize    | `false`                             | Whether gauge size should follow changes in container element size                         |
-| counter              | `false`                             | Animate text value number change                                                           |
-| decimals             | `0`                                 | Number of digits after floating point                                                      |
-| customSectors        | `{}`                                | Custom sectors colors. Expects an [object](#Custom-Sectors)                                |
-| formatNumber         | `false`                             | Formats numbers with commas where appropriate                                              |
-| pointer              | `false`                             | Show value pointer                                                                         |
-| pointerOptions       | `{}`                                | Pointer options. Expects an [object](#Pointer-options)                                     |
-| displayRemaining     | `false`                             | Replace display number with the value remaining to reach max value                         |
+| Name                 | Default                             | Description                                                                                                     |
+| -------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| id                   | (required)                          | The HTML container element `id`                                                                                 |
+| value                | `0`                                 | Value Gauge is showing                                                                                          |
+| parentNode           | `null`                              | The HTML container element object. Used if `id` is not present                                                  |
+| defaults             | `false`                             | Defaults parameters to use globally for gauge objects                                                           |
+| width                | `null`                              | The Gauge width in pixels (Integer)                                                                             |
+| height               | `null`                              | The Gauge height in pixels                                                                                      |
+| valueFontColor       | `#010101`                           | Color of label showing current value                                                                            |
+| valueFontFamily      | `Arial`                             | Font of label showing current value                                                                             |
+| symbol               | `''`                                | Special symbol to show next to value                                                                            |
+| min                  | `0`                                 | Min value                                                                                                       |
+| minTxt               | `false`                             | Min value text, overrides `min` if specified                                                                    |
+| max                  | `100`                               | Max value                                                                                                       |
+| maxTxt               | `false`                             | Max value text, overrides `max` if specified                                                                    |
+| reverse              | `false`                             | Reverse min and max                                                                                             |
+| humanFriendlyDecimal | `0`                                 | Number of decimal places for our human friendly number to contain                                               |
+| textRenderer         | `null`                              | Function applied before redering text `(value) => value` return `false` to format value based on config options |
+| onAnimationEnd       | `null`                              | Function applied after animation is done                                                                        |
+| gaugeWidthScale      | `1.0`                               | Width of the gauge element                                                                                      |
+| gaugeColor           | `#edebeb`                           | Background color of gauge element                                                                               |
+| label                | `''`                                | Text to show below value                                                                                        |
+| labelFontColor       | `#b3b3b3`                           | Color of label showing label under value                                                                        |
+| shadowOpacity        | `0.2`                               | Shadow opacity 0 ~ 1                                                                                            |
+| shadowSize           | `5`                                 | Inner shadow size                                                                                               |
+| shadowVerticalOffset | `3`                                 | How much shadow is offset from top                                                                              |
+| levelColors          | `["#a9d70b", "#f9c802", "#ff0000"]` | Colors of indicator, from lower to upper, in RGB format                                                         |
+| startAnimationTime   | `700`                               | Length of initial animation in milliseconds                                                                     |
+| startAnimationType   | `>`                                 | Type of initial animation (linear, >, <,  <>, bounce)                                                           |
+| refreshAnimationTime | `700`                               | Length of refresh animation in milliseconds                                                                     |
+| refreshAnimationType | `>`                                 | Type of refresh animation (linear, >, <,  <>, bounce)                                                           |
+| donutStartAngle      | `90`                                | Angle to start from when in donut mode                                                                          |
+| valueMinFontSize     | `16`                                | Absolute minimum font size for the value label                                                                  |
+| labelMinFontSize     | `10`                                | Absolute minimum font size for the label                                                                        |
+| minLabelMinFontSize  | `10`                                | Absolute minimum font size for the min label                                                                    |
+| maxLabelMinFontSize  | `10`                                | Absolute minimum font size for the man label                                                                    |
+| hideValue            | `false`                             | Hide value text                                                                                                 |
+| hideMinMax           | `false`                             | Hide min/max text                                                                                               |
+| showInnerShadow      | `false`                             | Show inner shadow                                                                                               |
+| humanFriendly        | `false`                             | convert large numbers for min, max, value to human friendly (e.g. 1234567 -> 1.23M)                             |
+| noGradient           | `false`                             | Whether to use gradual color change for value, or sector-based                                                  |
+| donut                | `false`                             | Show donut gauge                                                                                                |
+| relativeGaugeSize    | `false`                             | Whether gauge size should follow changes in container element size                                              |
+| counter              | `false`                             | Animate text value number change                                                                                |
+| decimals             | `0`                                 | Number of digits after floating point                                                                           |
+| customSectors        | `{}`                                | Custom sectors colors. Expects an [object](#Custom-Sectors)                                                     |
+| formatNumber         | `false`                             | Formats numbers with commas where appropriate                                                                   |
+| pointer              | `false`                             | Show value pointer                                                                                              |
+| pointerOptions       | `{}`                                | Pointer options. Expects an [object](#Pointer-options)                                                          |
+| displayRemaining     | `false`                             | Replace display number with the value remaining to reach max value                                              |
 
 ### Custom Sectors
 

--- a/docs/examples/text-renderer-2.html
+++ b/docs/examples/text-renderer-2.html
@@ -100,7 +100,7 @@
                 title: "Score",
                 label: "",
                 pointer: true,
-                textRenderer: function (val) {
+                textRenderer: function (val, config) {
                     return (val + '/' + maxx);
                 },
                 onAnimationEnd: function () {

--- a/docs/examples/text-renderer-2.html
+++ b/docs/examples/text-renderer-2.html
@@ -100,7 +100,7 @@
                 title: "Score",
                 label: "",
                 pointer: true,
-                textRenderer: function (val, config) {
+                textRenderer: function (val) {
                     return (val + '/' + maxx);
                 },
                 onAnimationEnd: function () {

--- a/docs/justgage.js
+++ b/docs/justgage.js
@@ -724,7 +724,7 @@
 
     // set value to display
     if (obj.config.textRenderer) {
-      obj.originalValue = obj.config.textRenderer(obj.originalValue);
+      obj.originalValue = obj.config.textRenderer(obj.originalValue, obj.config);
     } else if (obj.config.humanFriendly) {
       obj.originalValue = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
     } else if (obj.config.formatNumber) {
@@ -743,7 +743,7 @@
           currentValue = (obj.config.max * 1) + (obj.config.min * 1) - (obj.level.attr("pki")[0] * 1);
         }
         if (obj.config.textRenderer) {
-          obj.txtValue.attr("text", obj.config.textRenderer(Math.floor(currentValue)));
+          obj.txtValue.attr("text", obj.config.textRenderer(Math.floor(currentValue), obj.config));
         } else if (obj.config.humanFriendly) {
           obj.txtValue.attr("text", humanFriendlyNumber(Math.floor(currentValue), obj.config.humanFriendlyDecimal) + obj.config.symbol);
         } else if (obj.config.formatNumber) {
@@ -915,7 +915,7 @@
     color = getColor(val, (val - obj.config.min) / (obj.config.max - obj.config.min), obj.config.levelColors, obj.config.noGradient, obj.config.customSectors);
 
     if (obj.config.textRenderer) {
-      displayVal = obj.config.textRenderer(displayVal);
+      displayVal = obj.config.textRenderer(displayVal, obj.config);
     } else if (obj.config.humanFriendly) {
       displayVal = humanFriendlyNumber(displayVal, obj.config.humanFriendlyDecimal) + obj.config.symbol;
     } else if (obj.config.formatNumber) {

--- a/docs/justgage.js
+++ b/docs/justgage.js
@@ -723,36 +723,45 @@
     defs, svg = null;
 
     // set value to display
+    // set original value to false before trying to call textRenderer for later check
+    obj.originalValue = false;
     if (obj.config.textRenderer) {
-      obj.originalValue = obj.config.textRenderer(obj.originalValue, obj.config);
-    } else if (obj.config.humanFriendly) {
-      obj.originalValue = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
-    } else if (obj.config.formatNumber) {
-      obj.originalValue = formatNumber(obj.originalValue) + obj.config.symbol;
-    } else if (obj.config.displayRemaining) {
-      obj.originalValue = ((obj.config.max - obj.originalValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
-    } else {
-      obj.originalValue = (obj.originalValue * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+      obj.originalValue = obj.config.textRenderer(obj.originalValue);
+    }
+    if (obj.originalValue === false) {
+      if (obj.config.humanFriendly) {
+        obj.originalValue = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
+      } else if (obj.config.formatNumber) {
+        obj.originalValue = formatNumber(obj.originalValue) + obj.config.symbol;
+      } else if (obj.config.displayRemaining) {
+        obj.originalValue = ((obj.config.max - obj.originalValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+      } else {
+        obj.originalValue = (obj.originalValue * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+      }
     }
 
     if (obj.config.counter === true) {
       //on each animation frame
       var onFrame = function () {
-        var currentValue = obj.level.attr("pki")[0];
+        var currentValue = obj.level.attr("pki")[0], valueToSet = false;
         if (obj.config.reverse) {
           currentValue = (obj.config.max * 1) + (obj.config.min * 1) - (obj.level.attr("pki")[0] * 1);
         }
         if (obj.config.textRenderer) {
-          obj.txtValue.attr("text", obj.config.textRenderer(Math.floor(currentValue), obj.config));
-        } else if (obj.config.humanFriendly) {
-          obj.txtValue.attr("text", humanFriendlyNumber(Math.floor(currentValue), obj.config.humanFriendlyDecimal) + obj.config.symbol);
-        } else if (obj.config.formatNumber) {
-          obj.txtValue.attr("text", formatNumber(Math.floor(currentValue)) + obj.config.symbol);
-        } else if (obj.config.displayRemaining) {
-          obj.txtValue.attr("text", ((obj.config.max - currentValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol);
-        } else {
-          obj.txtValue.attr("text", (currentValue * 1).toFixed(obj.config.decimals) + obj.config.symbol);
+          valueToSet = obj.config.textRenderer(Math.floor(currentValue));
+        } 
+        if (valueToSet === false) {
+          if (obj.config.humanFriendly) {
+            valueToSet = humanFriendlyNumber(Math.floor(currentValue), obj.config.humanFriendlyDecimal) + obj.config.symbol;
+          } else if (obj.config.formatNumber) {
+            valueToSet = formatNumber(Math.floor(currentValue)) + obj.config.symbol;
+          } else if (obj.config.displayRemaining) {
+            valueToSet = ((obj.config.max - currentValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+          } else {
+            valueToSet = (currentValue * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+          }
         }
+        obj.txtValue.attr("text", valueToSet);
         setDy(obj.txtValue, obj.params.valueFontSize, obj.params.valueY);
         currentValue = null;
       }
@@ -914,16 +923,21 @@
 
     color = getColor(val, (val - obj.config.min) / (obj.config.max - obj.config.min), obj.config.levelColors, obj.config.noGradient, obj.config.customSectors);
 
+    // set display value to false before trying to call textRenderer for later check
+    displayVal = false;
     if (obj.config.textRenderer) {
-      displayVal = obj.config.textRenderer(displayVal, obj.config);
-    } else if (obj.config.humanFriendly) {
-      displayVal = humanFriendlyNumber(displayVal, obj.config.humanFriendlyDecimal) + obj.config.symbol;
-    } else if (obj.config.formatNumber) {
-      displayVal = formatNumber((displayVal * 1).toFixed(obj.config.decimals)) + obj.config.symbol;
-    } else if (obj.config.displayRemaining) {
-      displayVal = ((obj.config.max - displayVal) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
-    } else {
-      displayVal = (displayVal * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+      displayVal = obj.config.textRenderer(displayVal);
+    }
+    if (displayVal === false) {
+      if (obj.config.humanFriendly) {
+        displayVal = humanFriendlyNumber(displayVal, obj.config.humanFriendlyDecimal) + obj.config.symbol;
+      } else if (obj.config.formatNumber) {
+        displayVal = formatNumber((displayVal * 1).toFixed(obj.config.decimals)) + obj.config.symbol;
+      } else if (obj.config.displayRemaining) {
+        displayVal = ((obj.config.max - displayVal) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+      } else {
+        displayVal = (displayVal * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+      }
     }
     obj.originalValue = displayVal;
     obj.config.value = val * 1;

--- a/docs/justgage.js
+++ b/docs/justgage.js
@@ -845,7 +845,7 @@
   JustGage.prototype.refresh = function (val, max, min, label) {
 
     var obj = this;
-    var displayVal, color;
+    var displayVal, displayValToSet, color;
 
     max = isNumber(max) ? max : null
     min = isNumber(min) ? min : null
@@ -924,22 +924,22 @@
     color = getColor(val, (val - obj.config.min) / (obj.config.max - obj.config.min), obj.config.levelColors, obj.config.noGradient, obj.config.customSectors);
 
     // set display value to false before trying to call textRenderer for later check
-    displayVal = false;
+    displayValToSet = false;
     if (obj.config.textRenderer) {
-      displayVal = obj.config.textRenderer(displayVal);
+      displayValToSet = obj.config.textRenderer(displayVal);
     }
-    if (displayVal === false) {
+    if (displayValToSet === false) {
       if (obj.config.humanFriendly) {
-        displayVal = humanFriendlyNumber(displayVal, obj.config.humanFriendlyDecimal) + obj.config.symbol;
+        displayValToSet = humanFriendlyNumber(displayVal, obj.config.humanFriendlyDecimal) + obj.config.symbol;
       } else if (obj.config.formatNumber) {
-        displayVal = formatNumber((displayVal * 1).toFixed(obj.config.decimals)) + obj.config.symbol;
+        displayValToSet = formatNumber((displayVal * 1).toFixed(obj.config.decimals)) + obj.config.symbol;
       } else if (obj.config.displayRemaining) {
-        displayVal = ((obj.config.max - displayVal) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+        displayValToSet = ((obj.config.max - displayVal) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
       } else {
-        displayVal = (displayVal * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+        displayValToSet = (displayVal * 1).toFixed(obj.config.decimals) + obj.config.symbol;
       }
     }
-    obj.originalValue = displayVal;
+    obj.originalValue = displayVal = displayValToSet;
     obj.config.value = val * 1;
 
     if (!obj.config.counter) {

--- a/docs/justgage.js
+++ b/docs/justgage.js
@@ -722,23 +722,26 @@
     // var clear
     defs, svg = null;
 
+    var orginalValueToSet;
+
     // set value to display
     // set original value to false before trying to call textRenderer for later check
-    obj.originalValue = false;
+    orginalValueToSet = false;
     if (obj.config.textRenderer) {
-      obj.originalValue = obj.config.textRenderer(obj.originalValue);
+      orginalValueToSet = obj.config.textRenderer(obj.originalValue);
     }
-    if (obj.originalValue === false) {
+    if (orginalValueToSet === false) {
       if (obj.config.humanFriendly) {
-        obj.originalValue = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
+        orginalValueToSet = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
       } else if (obj.config.formatNumber) {
-        obj.originalValue = formatNumber(obj.originalValue) + obj.config.symbol;
+        orginalValueToSet = formatNumber(obj.originalValue) + obj.config.symbol;
       } else if (obj.config.displayRemaining) {
-        obj.originalValue = ((obj.config.max - obj.originalValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+        orginalValueToSet = ((obj.config.max - obj.originalValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
       } else {
-        obj.originalValue = (obj.originalValue * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+        orginalValueToSet = (obj.originalValue * 1).toFixed(obj.config.decimals) + obj.config.symbol;
       }
     }
+    obj.originalValue = orginalValueToSet;
 
     if (obj.config.counter === true) {
       //on each animation frame

--- a/docs/justgage.js
+++ b/docs/justgage.js
@@ -722,49 +722,37 @@
     // var clear
     defs, svg = null;
 
-    var orginalValueToSet;
-
     // set value to display
-    // set original value to false before trying to call textRenderer for later check
-    orginalValueToSet = false;
-    if (obj.config.textRenderer) {
-      orginalValueToSet = obj.config.textRenderer(obj.originalValue);
+    if (obj.config.textRenderer && obj.config.textRenderer(obj.originalValue) !== false) {
+      obj.originalValue = obj.config.textRenderer(obj.originalValue);
+    } else if (obj.config.humanFriendly) {
+      obj.originalValue = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
+    } else if (obj.config.formatNumber) {
+      obj.originalValue = formatNumber(obj.originalValue) + obj.config.symbol;
+    } else if (obj.config.displayRemaining) {
+      obj.originalValue = ((obj.config.max - obj.originalValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+    } else {
+      obj.originalValue = (obj.originalValue * 1).toFixed(obj.config.decimals) + obj.config.symbol;
     }
-    if (orginalValueToSet === false) {
-      if (obj.config.humanFriendly) {
-        orginalValueToSet = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
-      } else if (obj.config.formatNumber) {
-        orginalValueToSet = formatNumber(obj.originalValue) + obj.config.symbol;
-      } else if (obj.config.displayRemaining) {
-        orginalValueToSet = ((obj.config.max - obj.originalValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
-      } else {
-        orginalValueToSet = (obj.originalValue * 1).toFixed(obj.config.decimals) + obj.config.symbol;
-      }
-    }
-    obj.originalValue = orginalValueToSet;
 
     if (obj.config.counter === true) {
       //on each animation frame
       var onFrame = function () {
-        var currentValue = obj.level.attr("pki")[0], valueToSet = false;
+        var currentValue = obj.level.attr("pki")[0];
         if (obj.config.reverse) {
           currentValue = (obj.config.max * 1) + (obj.config.min * 1) - (obj.level.attr("pki")[0] * 1);
         }
-        if (obj.config.textRenderer) {
-          valueToSet = obj.config.textRenderer(Math.floor(currentValue));
-        } 
-        if (valueToSet === false) {
-          if (obj.config.humanFriendly) {
-            valueToSet = humanFriendlyNumber(Math.floor(currentValue), obj.config.humanFriendlyDecimal) + obj.config.symbol;
-          } else if (obj.config.formatNumber) {
-            valueToSet = formatNumber(Math.floor(currentValue)) + obj.config.symbol;
-          } else if (obj.config.displayRemaining) {
-            valueToSet = ((obj.config.max - currentValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
-          } else {
-            valueToSet = (currentValue * 1).toFixed(obj.config.decimals) + obj.config.symbol;
-          }
+        if (obj.config.textRenderer && obj.config.textRenderer(Math.floor(currentValue)) !== false) {
+          obj.txtValue.attr("text", obj.config.textRenderer(Math.floor(currentValue)));
+        } else if (obj.config.humanFriendly) {
+          obj.txtValue.attr("text", humanFriendlyNumber(Math.floor(currentValue), obj.config.humanFriendlyDecimal) + obj.config.symbol);
+        } else if (obj.config.formatNumber) {
+          obj.txtValue.attr("text", formatNumber(Math.floor(currentValue)) + obj.config.symbol);
+        } else if (obj.config.displayRemaining) {
+          obj.txtValue.attr("text", ((obj.config.max - currentValue) * 1).toFixed(obj.config.decimals) + obj.config.symbol);
+        } else {
+          obj.txtValue.attr("text", (currentValue * 1).toFixed(obj.config.decimals) + obj.config.symbol);
         }
-        obj.txtValue.attr("text", valueToSet);
         setDy(obj.txtValue, obj.params.valueFontSize, obj.params.valueY);
         currentValue = null;
       }
@@ -848,7 +836,7 @@
   JustGage.prototype.refresh = function (val, max, min, label) {
 
     var obj = this;
-    var displayVal, displayValToSet, color;
+    var displayVal, color;
 
     max = isNumber(max) ? max : null
     min = isNumber(min) ? min : null
@@ -926,23 +914,18 @@
 
     color = getColor(val, (val - obj.config.min) / (obj.config.max - obj.config.min), obj.config.levelColors, obj.config.noGradient, obj.config.customSectors);
 
-    // set display value to false before trying to call textRenderer for later check
-    displayValToSet = false;
-    if (obj.config.textRenderer) {
-      displayValToSet = obj.config.textRenderer(displayVal);
+    if (obj.config.textRenderer && obj.config.textRenderer(displayVal) !== false) {
+      displayVal = obj.config.textRenderer(displayVal);
+    } else if (obj.config.humanFriendly) {
+      displayVal = humanFriendlyNumber(displayVal, obj.config.humanFriendlyDecimal) + obj.config.symbol;
+    } else if (obj.config.formatNumber) {
+      displayVal = formatNumber((displayVal * 1).toFixed(obj.config.decimals)) + obj.config.symbol;
+    } else if (obj.config.displayRemaining) {
+      displayVal = ((obj.config.max - displayVal) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
+    } else {
+      displayVal = (displayVal * 1).toFixed(obj.config.decimals) + obj.config.symbol;
     }
-    if (displayValToSet === false) {
-      if (obj.config.humanFriendly) {
-        displayValToSet = humanFriendlyNumber(displayVal, obj.config.humanFriendlyDecimal) + obj.config.symbol;
-      } else if (obj.config.formatNumber) {
-        displayValToSet = formatNumber((displayVal * 1).toFixed(obj.config.decimals)) + obj.config.symbol;
-      } else if (obj.config.displayRemaining) {
-        displayValToSet = ((obj.config.max - displayVal) * 1).toFixed(obj.config.decimals) + obj.config.symbol;
-      } else {
-        displayValToSet = (displayVal * 1).toFixed(obj.config.decimals) + obj.config.symbol;
-      }
-    }
-    obj.originalValue = displayVal = displayValToSet;
+    obj.originalValue = displayVal;
     obj.config.value = val * 1;
 
     if (!obj.config.counter) {

--- a/justgage.js
+++ b/justgage.js
@@ -723,8 +723,8 @@
     defs, svg = null;
 
     // set value to display
-    if (obj.config.textRenderer) {
-      obj.originalValue = obj.config.textRenderer(obj.originalValue, obj.config);
+    if (obj.config.textRenderer && obj.config.textRenderer(obj.originalValue) !== false) {
+      obj.originalValue = obj.config.textRenderer(obj.originalValue);
     } else if (obj.config.humanFriendly) {
       obj.originalValue = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
     } else if (obj.config.formatNumber) {
@@ -742,8 +742,8 @@
         if (obj.config.reverse) {
           currentValue = (obj.config.max * 1) + (obj.config.min * 1) - (obj.level.attr("pki")[0] * 1);
         }
-        if (obj.config.textRenderer) {
-          obj.txtValue.attr("text", obj.config.textRenderer(Math.floor(currentValue), obj.config));
+        if (obj.config.textRenderer && obj.config.textRenderer(Math.floor(currentValue)) !== false) {
+          obj.txtValue.attr("text", obj.config.textRenderer(Math.floor(currentValue)));
         } else if (obj.config.humanFriendly) {
           obj.txtValue.attr("text", humanFriendlyNumber(Math.floor(currentValue), obj.config.humanFriendlyDecimal) + obj.config.symbol);
         } else if (obj.config.formatNumber) {
@@ -914,8 +914,8 @@
 
     color = getColor(val, (val - obj.config.min) / (obj.config.max - obj.config.min), obj.config.levelColors, obj.config.noGradient, obj.config.customSectors);
 
-    if (obj.config.textRenderer) {
-      displayVal = obj.config.textRenderer(displayVal, obj.config);
+    if (obj.config.textRenderer && obj.config.textRenderer(displayVal) !== false) {
+      displayVal = obj.config.textRenderer(displayVal);
     } else if (obj.config.humanFriendly) {
       displayVal = humanFriendlyNumber(displayVal, obj.config.humanFriendlyDecimal) + obj.config.symbol;
     } else if (obj.config.formatNumber) {

--- a/justgage.js
+++ b/justgage.js
@@ -724,7 +724,7 @@
 
     // set value to display
     if (obj.config.textRenderer) {
-      obj.originalValue = obj.config.textRenderer(obj.originalValue);
+      obj.originalValue = obj.config.textRenderer(obj.originalValue, obj.config);
     } else if (obj.config.humanFriendly) {
       obj.originalValue = humanFriendlyNumber(obj.originalValue, obj.config.humanFriendlyDecimal) + obj.config.symbol;
     } else if (obj.config.formatNumber) {
@@ -743,7 +743,7 @@
           currentValue = (obj.config.max * 1) + (obj.config.min * 1) - (obj.level.attr("pki")[0] * 1);
         }
         if (obj.config.textRenderer) {
-          obj.txtValue.attr("text", obj.config.textRenderer(Math.floor(currentValue)));
+          obj.txtValue.attr("text", obj.config.textRenderer(Math.floor(currentValue), obj.config));
         } else if (obj.config.humanFriendly) {
           obj.txtValue.attr("text", humanFriendlyNumber(Math.floor(currentValue), obj.config.humanFriendlyDecimal) + obj.config.symbol);
         } else if (obj.config.formatNumber) {
@@ -915,7 +915,7 @@
     color = getColor(val, (val - obj.config.min) / (obj.config.max - obj.config.min), obj.config.levelColors, obj.config.noGradient, obj.config.customSectors);
 
     if (obj.config.textRenderer) {
-      displayVal = obj.config.textRenderer(displayVal);
+      displayVal = obj.config.textRenderer(displayVal, obj.config);
     } else if (obj.config.humanFriendly) {
       displayVal = humanFriendlyNumber(displayVal, obj.config.humanFriendlyDecimal) + obj.config.symbol;
     } else if (obj.config.formatNumber) {


### PR DESCRIPTION
Added config object to textRenderer function