### PR TITLE
fix: dtyle conflict with multiple gauges created using the "parentNode" method

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -1263,7 +1263,7 @@
    */
   JustGage.prototype.generateShadow = function (svg, defs) {
     const obj = this;
-    const sid = "inner-shadow-" + (obj.config.classId || obj.config.id);
+    const sid = "inner-shadow-" + (obj.config.id || obj.config.classId);
 
     // FILTER
     const gaussFilter = document.createElementNS(svg, "filter");

--- a/justgage.js
+++ b/justgage.js
@@ -1316,11 +1316,11 @@
     if (obj.config.showInnerShadow) {
       obj.canvas.canvas.childNodes[2].setAttribute(
         "filter",
-        "url(" + window.location.pathname + "#" + sid + ")"
+        "url("#" + sid + ")"
       );
       obj.canvas.canvas.childNodes[3].setAttribute(
         "filter",
-        "url(" + window.location.pathname + "#" + sid + ")"
+        "url("#" + sid + ")"
       );
     }
   };

--- a/justgage.js
+++ b/justgage.js
@@ -63,7 +63,7 @@
       
       // classId : string
       // this is the class id utilize when generating styles
-      classId: config.classId,
+      classId: uuid(),
 
       // value : float
       // value gauge is showing
@@ -1575,6 +1575,21 @@
 
   function isNumber(n) {
     return n !== null && n !== undefined && !isNaN(n);
+  }
+
+  /**
+   * Generate UUID
+   * @returns UUID
+   */
+  function uuid() {
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
+      /[xy]/g,
+      function (c) {
+        const r = (Math.random() * 16) | 0;
+        const v = c === "x" ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+      }
+    );
   }
 
   return JustGage;

--- a/justgage.js
+++ b/justgage.js
@@ -1316,11 +1316,11 @@
     if (obj.config.showInnerShadow) {
       obj.canvas.canvas.childNodes[2].setAttribute(
         "filter",
-        "url("#" + sid + ")"
+        "url(#" + sid + ")"
       );
       obj.canvas.canvas.childNodes[3].setAttribute(
         "filter",
-        "url("#" + sid + ")"
+        "url(#" + sid + ")"
       );
     }
   };

--- a/justgage.js
+++ b/justgage.js
@@ -60,6 +60,10 @@
       // id : string
       // this is container element id
       id: config.id,
+      
+      // classId : string
+      // this is the class id utilize when generating styles
+      classId: config.classId,
 
       // value : float
       // value gauge is showing
@@ -1259,7 +1263,7 @@
    */
   JustGage.prototype.generateShadow = function (svg, defs) {
     const obj = this;
-    const sid = "inner-shadow-" + obj.config.id;
+    const sid = "inner-shadow-" + (obj.config.classId || obj.config.id);
 
     // FILTER
     const gaussFilter = document.createElementNS(svg, "filter");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "justgage",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "JustGage is a handy JavaScript plugin for generating and animating nice & clean gauges. It is based on Raphaël library for vector drawing, so it’s completely resolution independent and self-adjusting.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "justgage",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "description": "JustGage is a handy JavaScript plugin for generating and animating nice & clean gauges. It is based on Raphaël library for vector drawing, so it’s completely resolution independent and self-adjusting.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When using the "parentNode" method to create gauges, the config.id remains undefined.

The code that generates the styles uses the config.id to define the id of the styles. Because config.id is undefined, this causes a style conflict resulting in every gauge in the screen being affected by the same style.

the config.id method takes precedence over parentNode which means you cannot use it at all.

I created a classId property that can be used to create a unique id for the styles for each instance. If the classId is not defined then the previous mechanism will be the default.